### PR TITLE
set up themed tab navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,65 @@
+import { tabs } from "@/constants/data";
+import { colors, components } from "@/constants/theme";
 import "@/global.css";
-import { Stack } from "expo-router";
+import clsx from "clsx";
+import { Tabs } from "expo-router";
+import { Image, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-export default function RootLayout() {
-  return <Stack screenOptions={{ headerShown: false }}></Stack>;
+const tabBar = components.tabBar;
+
+// interface TabIconProps {
+//   focused: boolean;
+//   icon: ReturnType<typeof require>;
+// }
+
+export default function TabLayout() {
+  const insets = useSafeAreaInsets();
+  const TabIcon = ({ focused, icon }: TabIconProps) => {
+    return (
+      <View className="tabs-icon">
+        <View className={clsx("tabs-pill", focused && "tabs-active")}>
+          <Image source={icon} className="tabs-glyph" />
+        </View>
+      </View>
+    );
+  };
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarShowLabel: false,
+        tabBarStyle: {
+          position: "absolute",
+          bottom: Math.max(insets.bottom, tabBar.horizontalInset),
+          height: tabBar.height,
+          marginHorizontal: tabBar.horizontalInset,
+          borderRadius: tabBar.radius,
+          backgroundColor: colors.primary,
+          borderTopWidth: 0,
+          elevation: 0,
+        },
+        tabBarIconStyle: {
+          paddingVertical: tabBar.height / (2 - tabBar.iconFrame / 1.4),
+          width: tabBar.iconFrame,
+          height: tabBar.iconFrame,
+          alignItems: "center",
+          justifyContent: "center",
+        },
+      }}
+    >
+      {tabs.map((tab) => (
+        <Tabs.Screen
+          key={tab.name}
+          name={tab.name}
+          options={{
+            title: tab.titel,
+            tabBarIcon: ({ focused }) => (
+              <TabIcon focused={focused} icon={tab.icon} />
+            ),
+          }}
+        />
+      ))}
+    </Tabs>
+  );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,40 +1,35 @@
 import "@/global.css";
 import { Link } from "expo-router";
-import { Text, View } from "react-native";
+import { styled } from "nativewind";
+import { Text } from "react-native";
+import { SafeAreaView as RNSafeAreaView } from "react-native-safe-area-context";
+
+const SafeAreaView = styled(RNSafeAreaView);
 
 export default function App() {
   return (
-    <>
-      <View className=" flex-1 items-center justify-center  bg-background">
-        <Text className=" text-3xl font-bold text-success">
-          Welcome to my App
-        </Text>
-      </View>
-
-      <View className="flex-1 items-center justify-center bg-background">
-        <Text className="text-xl font-bold text-success">
-          Welcome to Nativewind!
-        </Text>
-        <Link
-          href="./onboarding"
-          className="mt-4 rounded bg-primary text-white p-4"
-        >
-          Go to Onboarding
-        </Link>
-        <Link
-          href="./(auth)/sign-in"
-          className="mt-4 rounded bg-primary text-white p-4"
-        >
-          Go to Sign in
-        </Link>
-        <Link
-          href="./(auth)/sign-up"
-          className="mt-4 rounded bg-primary text-white p-4"
-        >
-          Go to Sign up
-        </Link>
-        I
-      </View>
-    </>
+    <SafeAreaView className="flex-1 bg-background p-5">
+      <Text className="text-xl font-bold text-success">
+        Welcome to Nativewind!
+      </Text>
+      <Link
+        href="./onboarding"
+        className="mt-4 rounded bg-primary text-white p-4"
+      >
+        Go to Onboarding
+      </Link>
+      <Link
+        href="./(auth)/sign-in"
+        className="mt-4 rounded bg-primary text-white p-4"
+      >
+        Go to Sign in
+      </Link>
+      <Link
+        href="./(auth)/sign-up"
+        className="mt-4 rounded bg-primary text-white p-4"
+      >
+        Go to Sign up
+      </Link>
+    </SafeAreaView>
   );
 }

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -1,11 +1,15 @@
+import { styled } from "nativewind";
 import React from "react";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+import { SafeAreaView as RNSafeAreaView } from "react-native-safe-area-context";
+
+const SafeAreaView = styled(RNSafeAreaView);
 
 const insights = () => {
   return (
-    <View>
+    <SafeAreaView className="flex-1 bg-background p-5">
       <Text>insights</Text>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,11 +1,15 @@
+import { styled } from "nativewind";
 import React from "react";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+import { SafeAreaView as RNSafeAreaView } from "react-native-safe-area-context";
+
+const SafeAreaView = styled(RNSafeAreaView);
 
 const settings = () => {
   return (
-    <View>
+    <SafeAreaView className="flex-1 bg-background p-5">
       <Text>settings</Text>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/(tabs)/supscriptions.tsx
+++ b/app/(tabs)/supscriptions.tsx
@@ -1,11 +1,15 @@
+import { styled } from "nativewind";
 import React from "react";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+import { SafeAreaView as RNSafeAreaView } from "react-native-safe-area-context";
+
+const SafeAreaView = styled(RNSafeAreaView);
 
 const supscriptions = () => {
   return (
-    <View>
+    <SafeAreaView className="flex-1 bg-background p-5">
       <Text>supscriptions</Text>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function Index() {
+  return <Redirect href="/(tabs)" />;
+}

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -1,0 +1,51 @@
+export const colors = {
+  background: "#fff9e3",
+  foreground: "#081126",
+  card: "#fff8e7",
+  muted: "#f6eecf",
+  mutedForeground: "rgba(0, 0, 0, 0.6)",
+  primary: "#081126",
+  accent: "#ea7a53",
+  border: "rgba(0, 0, 0, 0.1)",
+  success: "#16a34a",
+  destructive: "#dc2626",
+  subscription: "#8fd1bd",
+} as const;
+
+export const spacing = {
+  0: 0,
+  1: 4,
+  2: 8,
+  3: 12,
+  4: 16,
+  5: 20,
+  6: 24,
+  7: 28,
+  8: 32,
+  9: 36,
+  10: 40,
+  11: 44,
+  12: 48,
+  14: 56,
+  16: 64,
+  18: 72,
+  20: 80,
+  24: 96,
+  30: 120,
+} as const;
+
+export const components = {
+  tabBar: {
+    height: spacing[18],
+    horizontalInset: spacing[5],
+    radius: spacing[8],
+    iconFrame: spacing[12],
+    itemPaddingVertical: spacing[2],
+  },
+} as const;
+
+export const theme = {
+  colors,
+  spacing,
+  components,
+} as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "apptutorial",
+  "name": "sup-maneger",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "apptutorial",
+      "name": "sup-maneger",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
Add a shared tab bar theme, redirect the root route into the tabs stack, and wrap the tab screens in safe-area layouts.